### PR TITLE
Switch to using DevServicesConfig

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,11 +45,11 @@ jobs:
         if: startsWith(matrix.os, 'windows')
 
       - uses: actions/checkout@v3
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
           cache: 'maven'
 
       - name: Build with Maven

--- a/.github/workflows/quarkus-snapshot.yaml
+++ b/.github/workflows/quarkus-snapshot.yaml
@@ -10,7 +10,7 @@ on:
 env:
   ECOSYSTEM_CI_REPO: quarkusio/quarkus-ecosystem-ci
   ECOSYSTEM_CI_REPO_FILE: context.yaml
-  JAVA_VERSION: 11
+  JAVA_VERSION: 17
 
   #########################
   # Repo specific setting #

--- a/deployment/src/main/java/io/quarkiverse/code/server/deployment/devservice/CodeServerDevServiceBuildTimeConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/code/server/deployment/devservice/CodeServerDevServiceBuildTimeConfig.java
@@ -3,34 +3,34 @@ package io.quarkiverse.code.server.deployment.devservice;
 import java.util.Map;
 import java.util.Optional;
 
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
 
-@ConfigRoot(name = "quarkus.code-server.devservices", phase = ConfigPhase.BUILD_TIME)
-public class CodeServerDevServiceBuildTimeConfig {
+@ConfigRoot(phase = ConfigPhase.BUILD_TIME)
+@ConfigMapping(prefix = "quarkus.code-server.devservices")
+public interface CodeServerDevServiceBuildTimeConfig {
 
     /**
      * Whether to enable the code server dev service.
      */
-    @ConfigItem
-    public Optional<Boolean> enabled = Optional.empty();
+    Optional<Boolean> enabled();
 
     /**
      * Optional fixed port the dev service will listen to.
      * <p>
      * If not defined, the port will be chosen randomly.
      */
-    @ConfigItem
-    public Optional<Integer> port;
+    Optional<Integer> port();
 
     /**
      * The code-server image to use.
      * Uses linuxserver/code-server by default because it allows configuration by environment variables
      * as opposed requiring mounting files.
      */
-    @ConfigItem(defaultValue = "lscr.io/linuxserver/code-server:latest")
-    public String imageName;
+    @WithDefault("lscr.io/linuxserver/code-server:latest")
+    String imageName();
 
     /**
      * Indicates if the Code Server instance managed by Quarkus Dev Services is shared.
@@ -43,8 +43,8 @@ public class CodeServerDevServiceBuildTimeConfig {
      * <p>
      * Container sharing is only used in dev mode.
      */
-    @ConfigItem(defaultValue = "false")
-    public boolean shared;
+    @WithDefault("false")
+    boolean shared();
 
     /**
      * The value of the {@code quarkus-dev-service-code-server} label attached to the started container.
@@ -56,13 +56,12 @@ public class CodeServerDevServiceBuildTimeConfig {
      * <p>
      * This property is used when you need multiple shared Apicurio Registry instances.
      */
-    @ConfigItem(defaultValue = "code-server")
-    public String serviceName;
+    @WithDefault("code-server")
+    String serviceName();
 
     /**
      * Environment variables that are passed to the container.
      */
-    @ConfigItem
-    public Map<String, String> containerEnv;
+    Map<String, String> containerEnv();
 
 }

--- a/deployment/src/main/java/io/quarkiverse/code/server/deployment/devservice/CodeServerDevUIProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/code/server/deployment/devservice/CodeServerDevUIProcessor.java
@@ -6,14 +6,14 @@ import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.dev.devservices.DevServiceDescriptionBuildItem;
-import io.quarkus.deployment.dev.devservices.GlobalDevServicesConfig;
+import io.quarkus.deployment.dev.devservices.DevServicesConfig;
 import io.quarkus.devui.spi.page.CardPageBuildItem;
 import io.quarkus.devui.spi.page.Page;
 
 /**
  * Starts Code Server as dev service if needed.
  */
-@BuildSteps(onlyIf = { IsDevelopment.class, GlobalDevServicesConfig.Enabled.class })
+@BuildSteps(onlyIf = { IsDevelopment.class, DevServicesConfig.Enabled.class })
 public class CodeServerDevUIProcessor {
 
     @BuildStep(onlyIf = IsDevelopment.class)

--- a/deployment/src/main/java/io/quarkiverse/code/server/deployment/devservice/CodeServerProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/code/server/deployment/devservice/CodeServerProcessor.java
@@ -23,7 +23,7 @@ import io.quarkus.deployment.builditem.DockerStatusBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.console.ConsoleInstalledBuildItem;
 import io.quarkus.deployment.console.StartupLogCompressor;
-import io.quarkus.deployment.dev.devservices.GlobalDevServicesConfig;
+import io.quarkus.deployment.dev.devservices.DevServicesConfig;
 import io.quarkus.deployment.logging.LoggingSetupBuildItem;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.devservices.common.ConfigureUtil;
@@ -33,7 +33,7 @@ import io.quarkus.runtime.LaunchMode;
 /**
  * Starts Code Server as dev service if needed.
  */
-@BuildSteps(onlyIf = { IsDevelopment.class, GlobalDevServicesConfig.Enabled.class })
+@BuildSteps(onlyIf = { IsDevelopment.class, DevServicesConfig.Enabled.class })
 public class CodeServerProcessor {
 
     private static final Logger log = Logger.getLogger(CodeServerProcessor.class);
@@ -63,7 +63,7 @@ public class CodeServerProcessor {
             Optional<ConsoleInstalledBuildItem> consoleInstalledBuildItem,
             CuratedApplicationShutdownBuildItem closeBuildItem,
             CurateOutcomeBuildItem curateOutcomeBuildItem,
-            LoggingSetupBuildItem loggingSetupBuildItem, GlobalDevServicesConfig devServicesConfig) {
+            LoggingSetupBuildItem loggingSetupBuildItem, DevServicesConfig devServicesConfig) {
 
         File workspaceDir = curateOutcomeBuildItem.getApplicationModel().getAppArtifact().getWorkspaceModule().getModuleDir();
 
@@ -85,7 +85,7 @@ public class CodeServerProcessor {
 
         try {
             devService = startCodeServer(dockerStatusBuildItem, configuration, launchMode,
-                    !devServicesSharedNetworkBuildItem.isEmpty(), devServicesConfig.timeout);
+                    !devServicesSharedNetworkBuildItem.isEmpty(), devServicesConfig.timeout());
             compressor.close();
         } catch (Throwable t) {
             compressor.closeAndDumpCaptured();

--- a/deployment/src/main/java/io/quarkiverse/code/server/deployment/devservice/CodeServerProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/code/server/deployment/devservice/CodeServerProcessor.java
@@ -207,12 +207,12 @@ public class CodeServerProcessor {
         private final File workspaceDir;
 
         public CodeServerDevServiceCfg(CodeServerDevServiceBuildTimeConfig config, File workspaceDir) {
-            this.devServicesEnabled = config.enabled.orElse(true);
-            this.imageName = config.imageName;
-            this.fixedExposedPort = config.port.orElse(0);
-            this.shared = config.shared;
-            this.serviceName = config.serviceName;
-            this.containerEnv = config.containerEnv;
+            this.devServicesEnabled = config.enabled().orElse(true);
+            this.imageName = config.imageName();
+            this.fixedExposedPort = config.port().orElse(0);
+            this.shared = config.shared();
+            this.serviceName = config.serviceName();
+            this.containerEnv = config.containerEnv();
             this.workspaceDir = workspaceDir;
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,10 +24,10 @@
   </scm>
   <properties>
     <compiler-plugin.version>3.11.0</compiler-plugin.version>
-    <maven.compiler.release>11</maven.compiler.release>
+    <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus.version>3.5.2</quarkus.version>
+    <quarkus.version>3.20.0</quarkus.version>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
GlobalDevServicesConfig will be dropped in 3.26 so we should avoid it.

> [!WARNING]
> Note that this requires to set the minimum version to 3.20, so you might have to have a maintenance branch for 3.15 if you want to push new versions supporting 3.15 after this is in.